### PR TITLE
feat: add $watch for changes to '.data'

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -29,17 +29,23 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
         }
       }
 
+      var parseOpts = function(modelOptions) {
+        var opts = angular.extend({}, options, modelOptions);
+
+          if (isSelect) {
+              // Use <select multiple> instead
+              delete opts.multiple;
+              delete opts.initSelection;
+          } else if (isMultiple) {
+              opts.multiple = true;
+          }
+        return opts;
+      }
+
+
       return function (scope, elm, attrs, controller) {
         // instance-specific options
-        var opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2));
-
-        if (isSelect) {
-          // Use <select multiple> instead
-          delete opts.multiple;
-          delete opts.initSelection;
-        } else if (isMultiple) {
-          opts.multiple = true;
-        }
+        var opts = parseOpts(scope.$eval(attrs.uiSelect2));
 
         if (controller) {
           // Watch the model for programmatic changes
@@ -104,6 +110,21 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
         attrs.$observe('disabled', function (value) {
           elm.select2(value && 'disable' || 'enable');
         });
+        
+        if (attrs.uiSelect2 !== '' && attrs.uiSelect2 !== undefined)
+        {
+          var dataWatch = attrs.uiSelect2 + '.data';
+
+          scope.$watch(dataWatch, function(newValue, oldValue) {
+            if (!newValue) return;
+                              
+            $timeout(function() {
+                opts = parseOpts(scope.$eval(attrs.uiSelect2));
+                elm.select2(opts);
+                elm.trigger('change');
+            });
+          });
+        }
 
         if (attrs.ngMultiple) {
           scope.$watch(attrs.ngMultiple, function(newVal) {


### PR DESCRIPTION
- When there is a ui-select2 attribute, the relevant model is not
  watched for changes, so refreshing possible selections is impossible
  - Add a $watch over the scope objects '.data' object, and reinit
    select2 with new options
