### PR TITLE
Added destroy handler to remove the select2 when the parent element is removed from DOM

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -113,6 +113,10 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             }
           }
         }
+        
+        elm.bind("$destroy", function() {
+          elm.select2("destroy");
+        });
 
         attrs.$observe('disabled', function (value) {
           elm.select2('enable', !value);


### PR DESCRIPTION
If I have `<select ui-if='some-condition' ui-select2 ... ></select>`, when `some-condition` is false, the select2 generated artifact is left behind. I am not sure if there is a better way than doing this in a $destroy handler or I am doing my code the wrong way. - Thx
