### PR TITLE
Add Select2 JS and CSS includes to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ To your `bower.json` file. Then run
 
 This will copy the ui-select2 files into your `components` folder, along with its dependencies. Load the script files in your application:
 ```html
+<link rel="stylesheet" href="components/select2/select2.css">
 <script type="text/javascript" src="components/jquery/jquery.js"></script>
+<script type="text/javascript" src="components/select2/select2.js"></script>
 <script type="text/javascript" src="components/angular/angular.js"></script>
 <script type="text/javascript" src="components/angular-ui-select2/src/select2.js"></script>
 ```


### PR DESCRIPTION
Usage example is missing files Select2 needs. Without JS there is error message about missing select2 from elm, since it's missing from jQuery object. Without CSS Select2 is unusable, since elements it creates won't align as they should.
