### PR TITLE
[#22] Update model when using multiple for input.

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -43,6 +43,15 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
 
         if (controller) {
           // Watch the model for programmatic changes
+           scope.$watch(tAttrs.ngModel, function(current, old) {
+            if (!current) {
+              return
+            }
+            if (current == old) {
+              return
+            }
+            controller.$render()
+          }, true)
           controller.$render = function () {
             if (isSelect) {
               elm.select2('val', controller.$viewValue);

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -328,5 +328,19 @@ describe('uiSelect2', function () {
       // TODO: programmactically select an option
       // expect(scope.foo).toBe(/*  selected val  */) ;
     });
+
+    it('updated the view when model changes with complex object', function(){
+      scope.foo = [{'id': '0', 'text': '0'}];
+      scope.options['multiple'] = true
+      var element = compile('<input ng-model="foo" ui-select2="options">');
+      scope.$digest()
+
+      scope.foo.push({'id': '1', 'text': '1'})
+      scope.$digest()
+
+      expect(element.select2('data')).toEqual(
+        [{'id': '0', 'text': '0'}, {'id': '1', 'text': '1'}]);
+    });
+
   });
 });


### PR DESCRIPTION
## Problem description

When the model uses an array of objects, updating the model does not update the ui-select2 view.

Here is an example demonstrating the problem http://jsfiddle.net/hWXBv/25/

This is an attempt to fix #22
## Changes

I don't know much about angular and ui-select2 and JS in general, but I tried to help.

Also the documentation is sparse so I don't know how exactly ui-select2 should behave.

It looks like controler.render() does not detect chagnes when the model is an array of objects.

I have added a watch expression with 'deep' search so that watch function is called when model changes.

The fix is stupid since I did not want to do to much changes and break the other tests. Unfortunately the test suite is full of 

Maybe the whole contoller.render could be implemented in the watch function.
## How to test

There is a simple test to check the condition.

Please take a look at the model and suggest changes.
