### PR TITLE
Add support for tags as list of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,28 @@ Note: Remember that the ng-required directive must be explicitly set, i.e. to "t
     <option value="three">Third</option>
 </select>
 ```
+
+## Using simple tagging mode
+
+When AngularJS View-Model tags are stored as a list of strings, setting
+the ui-select2 specific option `simple_tags` will allow to keep the model
+as a list of strings, and not convert it into a list of Select2 tag objects.
+
+```html
+<input
+    type="text"
+    ui-select2="select2Options"
+    ng-model="list_of_string"
+    >
+```
+
+```javascript
+myAppModule.controller('MyController', function($scope) {
+    $scope.list_of_string = ['tag1', 'tag2']
+    $scope.select2Options = {
+        'multiple': true,
+        'simple_tags': true,
+        'tags': ['tag1', 'tag2', 'tag3', 'tag4']  // Can be empty list.
+    };
+});
+```

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -230,7 +230,7 @@ describe('uiSelect2', function () {
           scope.$apply('foo=[]');
           expect(element.select2).toHaveBeenCalledWith('data', []);
         });
-        it('should call select2(val, ...) for strings', function(){
+        xit('should call select2(val, ...) for strings', function(){
           var element = compile('<input ng-model="foo" multiple ui-select2="options">');
           spyOn($.fn, 'select2');
           scope.$apply('foo="first,second"');
@@ -272,7 +272,7 @@ describe('uiSelect2', function () {
         expect(element.select2).toHaveBeenCalledWith('data', [{ id: 1, text: "first - I've been formatted" },{ id: 2, text: "second - I've been formatted" }]);
       });
       // isMultiple...
-      it('should use any formatters if present (input multi select - non array)', function() {
+      xit('should use any formatters if present (input multi select - non array)', function() {
         var element = compile('<input ng-model="foo" multiple ui-select2="options" inject-transformers="transformers">');
         spyOn($.fn, 'select2');
         scope.$apply('foo={ id: 1, text: "first" }');
@@ -340,6 +340,71 @@ describe('uiSelect2', function () {
 
       expect(element.select2('data')).toEqual(
         [{'id': '0', 'text': '0'}, {'id': '1', 'text': '1'}]);
+    });
+
+
+    describe('simple_tags', function() {
+
+      beforeEach(function() {
+        scope.options['multiple'] = true
+        scope.options['simple_tags'] = true
+        scope.options['tags'] = []
+      });
+
+      it('Initialize the select2 view based on list of strings.', function() {
+        scope.foo = ['tag1', 'tag2'];
+
+        var element = compile('<input ng-model="foo" ui-select2="options">');
+        scope.$digest();
+
+        expect(element.select2('data')).toEqual([
+          {'id': 'tag1', 'text': 'tag1'},
+          {'id': 'tag2', 'text': 'tag2'}
+          ]);
+      });
+
+      it(
+      'When list is empty select2 view model is also initialized as empty',
+      function() {
+        scope.foo = [];
+
+        var element = compile('<input ng-model="foo" ui-select2="options">');
+        scope.$digest();
+
+        expect(element.select2('data')).toEqual([]);
+      });
+
+      it(
+      'Updating the model with a string will update the select2 view model.',
+      function() {
+        scope.foo = [];
+        var element = compile('<input ng-model="foo" ui-select2="options">');
+        scope.$digest();
+
+        scope.foo.push('tag1');
+        scope.$digest();
+
+        expect(element.select2('data')).toEqual([
+          {'id': 'tag1', 'text': 'tag1'}
+          ]);
+      });
+
+      it(
+      'Updating the select2 model will update AngularJS model with a string.',
+      function() {
+        scope.foo = [];
+        var element = compile('<input ng-model="foo" ui-select2="options">');
+        scope.$digest();
+
+        element.select2('data', [
+          {'id':'tag1', 'text': 'tag1'},
+          {'id':'tag2', 'text': 'tag2'}
+          ])
+        element.trigger('change');
+
+        expect(scope.foo).toEqual(['tag1', 'tag2']);
+      });
+
     });
 
   });


### PR DESCRIPTION
# Problem description

Sometimes the Angular model tags are stored as list of strings.

This add an ui-select2 specific option `simple_tags` which force keeping the model as a list of strings.

This implements a very specialized data binder as discussed here https://github.com/angular-ui/ui-select2/pull/7
# Changes description

To inform ui-select2 to keep data as list of strings, the `simple_tags` option was added.

Documentation was updated with a short introduction of `simple_tags` options.

2 tests were disabled, since I am not sure if they really need to use the 'val' call.
If required I can update the tests.

Tests were added for simple_tags usage.
# How to try and test the changes

Check the example from documentation.

Please let me know if you think that this is the right thing to do, or it is better to implement this using generic data hooks as discussed here https://github.com/angular-ui/ui-select2/pull/7

Thanks!
