### PR TITLE
Fix for IE8 splitting strings with forEach

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -60,7 +60,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
 
           if (opts.simple_tags) {
             model = [];
-            angular_data = typeof angular_data == "string" && angular_data.indexOf(",") > -1 ? angular_data.split(",") : [angular_data]
+            if(typeof angular_data == "string") {
+              angular_data = angular_data.indexOf(",") > -1 ? angular_data.split(",") : [angular_data];
+            }  
             angular.forEach(
               angular_data,
               function(value, index) {

--- a/src/select2.js
+++ b/src/select2.js
@@ -60,6 +60,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
 
           if (opts.simple_tags) {
             model = [];
+            angular_data = typeof angular_data == "string" && angular_data.indexOf(",") > -1 ? angular_data.split(",") : [angular_data]
             angular.forEach(
               angular_data,
               function(value, index) {


### PR DESCRIPTION
In IE8 when convertToSelect2Model is called on a String the forEach will split on each character. This fix prevents that.
