### PR TITLE
Added whitelist for storing options in attributes

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -6,6 +6,7 @@
  * @params [options] {object} The configuration options passed to $.fn.select2(). Refer to the documentation
  */
 angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelect2', ['uiSelect2Config', '$timeout', function (uiSelect2Config, $timeout) {
+  ATTR_WHITELIST = ['width', 'placeholder', 'minimumResultsForSearch'];
   var options = {};
   if (uiSelect2Config) {
     angular.extend(options, uiSelect2Config);
@@ -31,7 +32,12 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
 
       return function (scope, elm, attrs, controller) {
         // instance-specific options
-        var opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2));
+        instOpts = {};
+        angular.forEach(attrs, function(value, attr){
+            if (ATTR_WHITELIST.indexOf(attr) > -1)
+                instOpts[attr] = value;
+        });
+        var opts = angular.extend({}, options, scope.$eval(attrs.uiSelect2), instOpts);
 
         /*
         Convert from Select2 view-model to Angular view-model.


### PR DESCRIPTION
Adds the ability to attributes directly instead of using the ui-select2="{}" for setting select specific options.

ex:

``` html
<fieldset data-ng-repeat="comp in complications">
    <select ui-select2
                width='100%'
                minimum-results-for-search='-1'
                data-placeholder='Chose an option'
                data-ng-model="select[$index]"
                data-disabled="{{ !selects[comp.spec_field] }}"
                data-ng-change="calculateSelects($index)">
            <option value=""></option>
            <option ng-repeat="(_, spec) in selects[comp.spec_field]" value="{{ spec.guids }}">{{ spec.title.join(', ') }}</option>
    </select>
</fieldset>
```
