### PR TITLE
Added if statement to allow string 'false' in the disabled

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -162,6 +162,8 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
         });
 
         attrs.$observe('disabled', function (value) {
+          if (value === 'false')
+            value = false;
           elm.select2('enable', !value);
         });
 


### PR DESCRIPTION
This makes the $observer check for `value === 'false'` so if the disable equivocates to false and angular places the string 'false' in the attribute, the $observer will still fucntion

``` html
<fieldset data-ng-repeat="comp in complications">
    <label>{{ comp.spec_field }}:</label>
    <select ui-select2
                width='100%'
                minimum-results-for-search='-1'
                data-placeholder='Chose an option'
                data-ng-model="select[$index]"
                data-disabled="{{ !selects[comp.spec_field] }}"
                data-ng-change="calculateSelects($index)">
            <option value=""></option>
            <option ng-repeat="(_, spec) in selects[comp.spec_field]" value="{{ spec.guids }}">{{ spec.title.join(', ') }}</option>
    </select>
</fieldset>
```
