### PR TITLE
ui-select2 set dirty flag after initialization when simple_tags mode is on

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -175,6 +175,23 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           });
         }
 
+        /*
+         Set view value, set pristine state on select2 element and restore pristine state
+         if it was set before we call controller.$setViewValue
+         */
+        var setInitialViewValue = function (angularModel) {
+          var parentForm = elm.inheritedData('$formController');
+          var wasParentFormPristine = parentForm ? parentForm.$pristine : null;
+
+          controller.$setViewValue(angularModel);
+
+          controller.$setPristine();
+          // restore pristine state
+          if (wasParentFormPristine) {
+            parentForm.$setPristine();
+          }
+        };
+
         // Initialize the plugin late so that the injected DOM does not disrupt the template compiler
         $timeout(function () {
           elm.select2(opts);
@@ -185,9 +202,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           controller.$render();
 
           // Not sure if I should just check for !isSelect OR if I should check for 'tags' key
-          if (!opts.initSelection && !isSelect)
-            controller.$setViewValue(
-              convertToAngularModel(elm.select2('data')));
+          if (!opts.initSelection && !isSelect) {
+            setInitialViewValue(convertToAngularModel(elm.select2('data')));
+          }
         });
       };
     }

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -405,7 +405,16 @@ describe('uiSelect2', function () {
         expect(scope.foo).toEqual(['tag1', 'tag2']);
       });
 
-    });
+      it('should return pristine state to true', function () {
+        scope.foo = ['tag1', 'tag2'];
 
+        compile('<form name="testForm"><input name="testElement" ng-model="foo" ui-select2="options"></form>');
+        scope.$digest();
+
+        expect(scope.testForm.$pristine).toBeTruthy();
+        expect(scope.testForm.testElement.$pristine).toBeTruthy();
+      });
+
+    });
   });
 });


### PR DESCRIPTION
Hi guys!

In my project I use simple_tags option. But after the form containing select2 control is loaded, $pristine flag of select2 control and parent form is set to false and $dirty flag is set to true, which seems to be not correct. Here is plnkr for the issue: http://plnkr.co/edit/TjUscmd0vrMzEqOBURTe?p=preview. I found the way to fix it but I would like someone to review my changes and maybe give me advice how to do it better.

Thanks
