### PR TITLE
Fixed IE bug with triggering events with string data type from input dir...

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -81,6 +81,10 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           }
 
           if (!isSelect) {
+            // Fixed IE bug with triggering events with string data type from input directive instead of objects processed by select2
+            if (!$sniffer.hasEvent('input')) {
+              elm.unbind("change");
+            }
             // Set the view and model value and update the angular template manually for the ajax/multiple select2.
             elm.bind("change", function () {
               if (scope.$$phase) return;


### PR DESCRIPTION
Fixed IE bug with triggering events with string data type from input directive instead of objects processed by select2.

Under IE angular binds `change` event for input directive. It collides with select2 events. The result is that input triggers change events that contains strings instead of objects from select2 directive.
