### PR TITLE
Make tests pass

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,11 +10,11 @@
   ],
   "main": "./src/select2.js",
   "dependencies": {
-    "angular": ">= 1.0.2",
+    "angular": ">=1.0.2 <1.2",
     "select2": "~3.4",
     "jquery": ">=1.6.4"
   },
   "devDependencies": {
-    "angular-mocks": ">= 1.0.2"
+    "angular-mocks": ">=1.0.2 <1.2"
   }
 }


### PR DESCRIPTION
ui-select2 isn't currently compatible with Angular 1.2 because it references ngMultiple, which was removed, so I locked down the version number in bower.json to a version of Angular prior to 1.2 to make the tests pass.
