### PR TITLE
Fix for auto sorting items in select element

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -95,7 +95,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             if (isSelect) {
               if (!init) {
                 elm.select2('val', controller.$viewValue);
-                init = true;
+				if (controller.$viewValue) {
+					init = true;
+				}
               }
             } else {
               if (opts.multiple) {

--- a/src/select2.js
+++ b/src/select2.js
@@ -16,6 +16,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
       var watch,
         repeatOption,
         repeatAttr,
+        init,
         isSelect = tElm.is('select'),
         isMultiple = (tAttrs.multiple !== undefined);
 
@@ -92,7 +93,10 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           }, true)
           controller.$render = function () {
             if (isSelect) {
-              elm.select2('val', controller.$viewValue);
+              if (!init) {
+                elm.select2('val', controller.$viewValue);
+                init = true;
+              }
             } else {
               if (opts.multiple) {
                 elm.select2(


### PR DESCRIPTION
There is a problem with select2 that if i had some optgroups and items in it and if i selected 1 item from the second and 1 item from the first, the second item was moved to first position.

I found in angular.js:

``` javascript
selectElement.bind('change', function() {
  scope.$apply(function() {
    var array = [];
    forEach(selectElement.find('option'), function(option) {
      if (option.selected) {
        array.push(option.value);
      }
    });
    ctrl.$setViewValue(array);
  });
});
```

that model is being filled by iterating the selected options in select element. So if we do this in ui-select2:

``` javascript
controller.$render = function () {
  if (isSelect) {
    elm.select2('val', controller.$viewValue);
  }
...
}
```

We actually update the element with model values and "resort" all items by the model. This is not a good approach I think.

I made a fix for it so the render will hit select element once (items get sorted at the beginning by model) and then after selecting options only model gets updated and items will be added. But they wont sync and user wont be confused by item getting away by sorting.

Also link to already reported issue #12 

EDIT: i see it doesnt make through tests. If there is someone who can fix it properly it would be very helpful. I have no time for this at the moment.
