### PR TITLE
Do not set $dirty flag on init

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -120,6 +120,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
                 elm.select2('val', controller.$viewValue);
                 // Refresh angular to remove the superfluous option
                 elm.trigger('change');
+                if(newVal && !oldVal) {
+                  controller.$setPristine(true);
+                }
               });
             });
           }

--- a/src/select2.js
+++ b/src/select2.js
@@ -112,7 +112,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           // Watch the options dataset for changes
           if (watch) {
             scope.$watch(watch, function (newVal, oldVal, scope) {
-              if (!newVal) {
+              if (angular.equals(newVal, oldVal)) {
                 return;
               }
               // Delayed so that the options have time to be rendered


### PR DESCRIPTION
With original code $dirty flag is set on select element right after page loaded, see [example](http://embed.plnkr.co/8sviCh/preview)
With fixed code $dirty flag is set only when select is really changed, see [example](http://embed.plnkr.co/HTBvdD/preview)
