### PR TITLE
chore: trigger view change on ngModel update.

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -89,6 +89,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
               return;
             }
             controller.$render();
+            if (!isSelect) {
+                elm.trigger('change');
+            }
           }, true);
           controller.$render = function () {
             if (isSelect) {


### PR DESCRIPTION
In tagging mode when the model changes, the select2('data') is in sync with the model, but the view does not updates the tag list. With the trigger in the ngModel watch, it does.
