### PR TITLE
Update select2.js

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -88,9 +88,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             if (current === old) {
               return;
             }
-            controller.$render();
+            controller.render();
           }, true);
-          controller.$render = function () {
+          controller.render = function () {
             if (isSelect) {
               elm.select2('val', controller.$viewValue);
             } else {


### PR DESCRIPTION
In AngularJS 1.2.1 the newly defined controller.$render method never got called. I believe because the method already exists and the call is done above the new declaration. Could be wrong on that though - just a guess. I just changed the method name to be unique and it is called now.
