### PR TITLE
Add a $watch on the value of the ui-select2 attribute

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -179,6 +179,13 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           });
         }
 
+        if (attrs.uiSelect2) {
+          scope.$watch(attrs.uiSelect2, function (newVal, oldVal, scope) {
+            elm.select2(newVal);
+            controller.$render();
+          }, true);
+        }
+
         // Initialize the plugin late so that the injected DOM does not disrupt the template compiler
         $timeout(function () {
           elm.select2(opts);


### PR DESCRIPTION
This guarantees that config changes will take effect immediately. I use it extensively for adding/removing items from the list of possible choices. Haven't noticed any performance degradation.
