### PR TITLE
fix(modeconvert): update AngularJS model with a string.

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -96,8 +96,12 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
               elm.select2('val', controller.$viewValue);
             } else {
               if (opts.multiple) {
+                var viewValue = controller.$viewValue;
+                if (angular.isString(controller.$viewValue)) {
+                  viewValue = viewValue.split(',');
+                }
                 elm.select2(
-                  'data', convertToSelect2Model(controller.$viewValue));
+                  'data', convertToSelect2Model(viewValue));
               } else {
                 if (angular.isObject(controller.$viewValue)) {
                   elm.select2('data', controller.$viewValue);

--- a/src/select2.js
+++ b/src/select2.js
@@ -97,7 +97,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             } else {
               if (opts.multiple) {
                 var viewValue = controller.$viewValue;
-                if (angular.isString(controller.$viewValue)) {
+                if (angular.isString(viewValue)) {
                   viewValue = viewValue.split(',');
                 }
                 elm.select2(


### PR DESCRIPTION
parse String $viewValue form “tag1,tag2” to [“tag1”, “tag2”] before
converting to Select2 model

Fixes the test: Updating the select2 model will update AngularJS model with a string.
