### PR TITLE
fix the bug initSelection not being called when multiple=true

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -197,10 +197,12 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
 
         // Initialize the plugin late so that the injected DOM does not disrupt the template compiler
         $timeout(function () {
-          elm.select2(opts);
-
           // Set initial value - I'm not sure about this but it seems to need to be there
           elm.val(controller.$viewValue);
+          
+          elm.select2(opts);
+
+
           // important!
           controller.$render();
 


### PR DESCRIPTION
the problem is ui-select2 init select2 plugin before it init the element val, and select2 do not call initSelection if the val of the element is empty.
so i change the line order to first init the element val and then start select2

plunker that contain both my fix and the original directive, comment out one of them and config the the parameters

http://plnkr.co/edit/T2hpQlUoL2qJAXIsgt8T
