### PR TITLE
Adding support for `select2` events

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -84,7 +84,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           // help with naming, because adding 'select2-' to every event should be optional.
           var prefixer = function(str){
             var prefixed = str.match(/select2-/);
-            return !prefixed ? "select2-".concat(str) : str;
+            return prefixed || (str === 'change') ? str : "select2-".concat(str);
           };
 
           // Link select2 callbacks from options

--- a/src/select2.js
+++ b/src/select2.js
@@ -81,6 +81,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
         }
 
         if(angular.isDefined(opts.callbacks)){
+          // help with naming, because adding 'select2-' to every callback should be optional.
           var prefixer = function(str){
             var prefixed = str.match(/select2-/);
             return !prefixed ? "select2-".concat(str) : str
@@ -91,7 +92,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             key = prefixer(key);
             elm.on(key, val);
           });
-          
+
           delete opts.callbacks;
         }
 

--- a/src/select2.js
+++ b/src/select2.js
@@ -80,20 +80,20 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           opts.multiple = true;
         }
 
-        if(angular.isDefined(opts.callbacks)){
-          // help with naming, because adding 'select2-' to every callback should be optional.
+        if(angular.isDefined(opts.events)){
+          // help with naming, because adding 'select2-' to every event should be optional.
           var prefixer = function(str){
             var prefixed = str.match(/select2-/);
-            return !prefixed ? "select2-".concat(str) : str
+            return !prefixed ? "select2-".concat(str) : str;
           };
 
           // Link select2 callbacks from options
-          angular.forEach(opts.callbacks, function(val, key){
+          angular.forEach(opts.events, function(val, key){
             key = prefixer(key);
             elm.on(key, val);
           });
 
-          delete opts.callbacks;
+          delete opts.events;
         }
 
 

--- a/src/select2.js
+++ b/src/select2.js
@@ -80,6 +80,22 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           opts.multiple = true;
         }
 
+        if(angular.isDefined(opts.callbacks)){
+          var prefixer = function(str){
+            var prefixed = str.match(/select2-/);
+            return !prefixed ? "select2-".concat(str) : str
+          };
+
+          // Link select2 callbacks from options
+          angular.forEach(opts.callbacks, function(val, key){
+            key = prefixer(key);
+            elm.on(key, val);
+          });
+          
+          delete opts.callbacks;
+        }
+
+
         if (controller) {
           // Watch the model for programmatic changes
            scope.$watch(tAttrs.ngModel, function(current, old) {

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -410,29 +410,40 @@ describe('uiSelect2', function () {
 
   });
 
-  describe('handle select2 callbacks', function(){
+  describe('handle select2 events', function(){
+
+    beforeEach(function(){
+      scope.options['events'] = {
+        'open' : function(){
+          console.log('Select just opened');
+        }
+      };
+    });
+
+    afterEach(function(){
+      delete scope.options['events'];
+    });
 
     var prefix = function(str){
       var prefixed = str.match(/select2-/);
-      return !prefixed ? "select2-".concat(str) : str
+      return !prefixed ? "select2-".concat(str) : str;
     };
+
+    it('should be present', function(){
+      expect(scope.options.events).toBeDefined();
+    });
 
     it('should add `select2-` to beginning of a string', function(){
       expect(prefix('open')).toEqual('select2-open');
     });
 
-    it('should rename callback name to meet `select2` callback convention', function(){
-      scope.options['callbacks'] = {
-        'open' : function(){
-          console.log('I\'m a callback');
-        }
-      }
-      angular.forEach(scope.options.callbacks, function(val, key){
-        scope.options.callbacks[prefix(key)] = val;
-        delete scope.options.callbacks[key];
+    it('should rename events name to meet `select2` event convention', function(){
+      angular.forEach(scope.options.events, function(val, key){
+        scope.options.events[prefix(key)] = val;
+        delete scope.options.events[key];
       });
-      expect(scope.options.callbacks['select2-open']).toBeDefined();
-      expect(scope.options.callbacks['open']).toBeUndefined();
+      expect(scope.options.events['select2-open']).toBeDefined();
+      expect(scope.options.events['open']).toBeUndefined();
     });
     
   });

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -414,12 +414,12 @@ describe('uiSelect2', function () {
 
     beforeEach(function(){
       scope.options['events'] = {
-          'change': function(e){
-            console.log('Things change...');
-          }
-        , 'open' : function(){
-            console.log('Select just opened');
-          }
+        'change': function(e){
+          console.log('Things change...');
+        }, 
+        'open' : function(){
+          console.log('Select just opened');
+        }
       };
     });
 

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -414,9 +414,12 @@ describe('uiSelect2', function () {
 
     beforeEach(function(){
       scope.options['events'] = {
-        'open' : function(){
-          console.log('Select just opened');
-        }
+          'change': function(e){
+            console.log('Things change...');
+          }
+        , 'open' : function(){
+            console.log('Select just opened');
+          }
       };
     });
 
@@ -426,15 +429,19 @@ describe('uiSelect2', function () {
 
     var prefix = function(str){
       var prefixed = str.match(/select2-/);
-      return !prefixed ? "select2-".concat(str) : str;
+      return prefixed || (str === 'change') ? str : "select2-".concat(str);
     };
 
     it('should be present', function(){
       expect(scope.options.events).toBeDefined();
     });
 
-    it('should add `select2-` to beginning of a string', function(){
+    it('should add `select2-` to beginning of "open"', function(){
       expect(prefix('open')).toEqual('select2-open');
+    });
+
+    it('should NOT add `select2-` to the beginning of a "change" event', function(){
+      expect(prefix('change')).toEqual('change');
     });
 
     it('should rename events name to meet `select2` event convention', function(){

--- a/test/select2Spec.js
+++ b/test/select2Spec.js
@@ -187,6 +187,7 @@ describe('uiSelect2', function () {
       expect(element.select2('val')).toBe('fourth');
     });
   });
+
   describe('with an <input> element', function () {
     describe('compiling this directive', function () {
       it('should throw an error if we have no model defined', function () {
@@ -408,4 +409,32 @@ describe('uiSelect2', function () {
     });
 
   });
+
+  describe('handle select2 callbacks', function(){
+
+    var prefix = function(str){
+      var prefixed = str.match(/select2-/);
+      return !prefixed ? "select2-".concat(str) : str
+    };
+
+    it('should add `select2-` to beginning of a string', function(){
+      expect(prefix('open')).toEqual('select2-open');
+    });
+
+    it('should rename callback name to meet `select2` callback convention', function(){
+      scope.options['callbacks'] = {
+        'open' : function(){
+          console.log('I\'m a callback');
+        }
+      }
+      angular.forEach(scope.options.callbacks, function(val, key){
+        scope.options.callbacks[prefix(key)] = val;
+        delete scope.options.callbacks[key];
+      });
+      expect(scope.options.callbacks['select2-open']).toBeDefined();
+      expect(scope.options.callbacks['open']).toBeUndefined();
+    });
+    
+  });
+
 });


### PR DESCRIPTION
I needed to be able to fire actions when a tag was added and removed, if this functionality already existed I couldn't find it from the source.

To add events you simply need to add an `events` option to your select2 options object:

``` javascript
$scope.options = {
    multiple: true
  , tags: ['one', 'two', 'three']
  , events: {
        'open' : function(e){
          console.log(e)
        }
     ,  'removing': function(e){
          console.log('removing a tag')
        }
    }
}
```
