### PR TITLE
ui-select2 does not split on select2's "separator" option for multiple tags

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -98,7 +98,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
               if (opts.multiple) {
                 var viewValue = controller.$viewValue;
                 if (angular.isString(viewValue)) {
-                  viewValue = viewValue.split(',');
+                  viewValue = viewValue.split(opts.separator);
                 }
                 elm.select2(
                   'data', convertToSelect2Model(viewValue));


### PR DESCRIPTION
Bug related to PR 6d63149b9c79452a67166ef3edad5383fb728326. Updated code to respect separator option instead of hard-coded comma. Splitting on a comma breaks if selected tag contains a comma e.g. selecting "Springsteen, Bruce" would cause two tags.
