### PR TITLE
Stabilize specs, lock jquery and select2 versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,8 @@
   "main": "./src/select2.js",
   "dependencies": {
     "angular": ">=1.2.0",
-    "select2": "~3.4",
-    "jquery": ">=1.6.4"
+    "select2": "3.4.5",
+    "jquery": "2.1.0"
   },
   "devDependencies": {
     "angular-mocks": ">=1.0.2"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // Dependencies
-      'bower_components/jquery/jquery.js',
+      'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/select2/select2.js',


### PR DESCRIPTION
Specs were failing out of the box with the fuzzy versioning. Updated dependencies and locked to versions with specs passing.
