### PR TITLE
Fix wrong $dirty flag when initializing settings select2 from expression

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -207,9 +207,12 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           // Not sure if I should just check for !isSelect OR if I should check for 'tags' key
           if (!opts.initSelection && !isSelect) {
             var isPristine = controller.$pristine;
-            controller.$setViewValue(
-              convertToAngularModel(elm.select2('data'))
-            );
+            //element is not select so initialization is execute after onChange (avoid wrong $dirty flag)
+            elm.bind("change", function () {
+                controller.$setViewValue(
+                    convertToAngularModel(elm.select2('data'))
+                );
+              });
             if (isPristine) {
               controller.$setPristine();
             }


### PR DESCRIPTION
Select2 is firing $dirty flag on form when settings are initialized from expression.

Reworked initializon for not select element to onChange events.

Original issue #151
