### PR TITLE
Enable watching on nested ng-repeats.

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -14,20 +14,17 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
     require: 'ngModel',
     priority: 1,
     compile: function (tElm, tAttrs) {
-      var watch,
-        repeatOption,
-        repeatAttr,
+      var watches = [],
         isSelect = tElm.is('select'),
         isMultiple = angular.isDefined(tAttrs.multiple);
 
       // Enable watching of the options dataset if in use
       if (tElm.is('select')) {
-        repeatOption = tElm.find( 'optgroup[ng-repeat], optgroup[data-ng-repeat], option[ng-repeat], option[data-ng-repeat]');
-
-        if (repeatOption.length) {
-          repeatAttr = repeatOption.attr('ng-repeat') || repeatOption.attr('data-ng-repeat');
-          watch = jQuery.trim(repeatAttr.split('|')[0]).split(' ').pop();
-        }
+        watches = tElm.find('[ng-repeat], [data-ng-repeat]').map(function() {
+          var repeatOption = $(this);
+          var repeatAttr = repeatOption.attr('ng-repeat') || repeatOption.attr('data-ng-repeat');
+          return jQuery.trim(repeatAttr.split('|')[0]).split(' ').pop();
+        }).get();
       }
 
       return function (scope, elm, attrs, controller) {
@@ -115,7 +112,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           };
 
           // Watch the options dataset for changes
-          if (watch) {
+          angular.forEach(watches, function(watch) {
             scope.$watch(watch, function (newVal, oldVal, scope) {
               if (angular.equals(newVal, oldVal)) {
                 return;
@@ -130,7 +127,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
                 }
               });
             });
-          }
+          });
 
           // Update valid and dirty statuses
           controller.$parsers.push(function (value) {
@@ -149,7 +146,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             // Set the view and model value and update the angular template manually for the ajax/multiple select2.
             elm.bind("change", function (e) {
               e.stopImmediatePropagation();
-              
+
               if (scope.$$phase || scope.$root.$$phase) {
                 return;
               }
@@ -199,8 +196,6 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
         $timeout(function () {
           elm.select2(opts);
 
-          // Set initial value - I'm not sure about this but it seems to need to be there
-          elm.select2('data', controller.$modelValue);
           // important!
           controller.$render();
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // Dependencies
-      'bower_components/jquery/jquery.js',
+      'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/select2/select2.js',


### PR DESCRIPTION
For the case when you have two nested ng-repeats: an outer one for `optgroup` and an inner repeat for the `option`s.

For example:

``` js
// using underscore's groupBy function
$scope.groupedCities = _.groupBy(cities, 'state')
```

``` html
<select ui-select2 multiple>

  <optgroup
    ng-repeat="(state, cities) in groupedCities"
    label="{{ state }}">

    <option
      ng-repeat="city in cities"
      ng-value="city.name">
      {{ city.name }}
    </option>

  </optgroup>

</select>
```

The current implementation only looks for `ng-repeat` on an option element - in this case it causes a scoping issue, because cities is only defined inside of the parent `ng-repeat`.  As a result the initial value would not be set correctly.

This change caused an error to sometimes be thrown on this line:

``` js
// Set initial value - I'm not sure about this but it seems to need to be there
elm.select2('data', controller.$modelValue);
```

Removing it fixed the problem - all the tests pass and everything worked correctly, but I didn't figure out why.

I can add a test for nested `ng-repeat` just wanted to get some feedback first...
