### PR TITLE
Renamed render method to avoid conflict.

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -91,7 +91,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             }
             controller.$render();
           }, true);
-          controller.$render = function () {
+          controller.$renderUI = function () {
             if (isSelect) {
               elm.select2('val', controller.$viewValue);
             } else {


### PR DESCRIPTION
Post Angular 1.2, the render method defined in select2.js clashes with Angular's native render method, thus, breaking the tagging functionality.

By renaming the method, this problem is averted.
