### PR TITLE
ui-select2 not working when combining multiple and ajax

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -98,6 +98,9 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
               if (opts.multiple) {
                 var viewValue = controller.$viewValue;
                 if (angular.isString(viewValue)) {
+                  if (opts.ajax) {
+                    return;
+                  }
                   viewValue = viewValue.split(',');
                 }
                 elm.select2(


### PR DESCRIPTION
I use the following config which use both multiple and ajax:

```
$scope.opts = {
    ajax: {
        url: "/....",
        initSelection: function(el, fn) {},
        multiple: true,
        data: function (term, page) {
            return { q: term };
        },
        results: function (data, page) { 
            return {results: data};
        }
    }
} 
```

However, the component always render 'undefined' when an option is selected, and clicking remove on the 'undefined' seems to not do anything. After inspecting, it turned out that the $watch handler always be triggered before the handler of 'change' event of select2 element, and the current value at that time is a string value instead of an array causing the select2 data to be reseted.

I've made a minor update to fix this bug. 
