### PR TITLE
Renamed render method to avoid conflict

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -91,7 +91,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
             }
             controller.$render();
           }, true);
-          controller.$render = function () {
+          controller.$renderUI = function () {
             if (isSelect) {
               elm.select2('val', controller.$viewValue);
             } else {
@@ -202,7 +202,7 @@ angular.module('ui.select2', []).value('uiSelect2Config', {}).directive('uiSelec
           // Set initial value - I'm not sure about this but it seems to need to be there
           elm.select2('data', controller.$modelValue);
           // important!
-          controller.$render();
+          controller.$renderUI();
 
           // Not sure if I should just check for !isSelect OR if I should check for 'tags' key
           if (!opts.initSelection && !isSelect) {


### PR DESCRIPTION
The previous pull request was missing a call to the new renderUI method. This one should fix it.

Post Angular 1.2, the render method defined in select2.js clashes with Angular's native render method, thus, breaking the tagging functionality.  By renaming the method, this problem is averted.
